### PR TITLE
Enabling usage over unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,15 @@ The package can be installed as:
   ]
   ```
   
+You may also establish a connection to the docker engine over a unix socket. To
+do this, set the host variable in your config to `"http+unix://PATH/"`. Note
+that `PATH` has to be URI-encoded, i.e. the default socket path would be
+`%2Fvar%2Frun%2Fdocker.sock`.
+
 ## Usage
  Dockerex is a lightweight client, which means you need to specify the endpoint and original docker params in a map format.
+Before making any requests, you have to start the HTTP client by calling
+`HTTPoison.start`.
 
  Some examples:
 

--- a/lib/dockerex/client.ex
+++ b/lib/dockerex/client.ex
@@ -10,12 +10,15 @@ defmodule Dockerex.Client do
     Application.get_env(:dockerex, :options)
   end
 
-  @default_headers %{"Content-Type" => "application/json"}
+  defp default_headers do
+    {:ok , hostname} = :inet.gethostname
+    %{"Content-Type" => "application/json", "Host" => hostname}
+  end
 
   @doc """
   Send a GET request to the Docker API at the speicifed resource.
   """
-  def get(resource, headers \\ @default_headers, opt \\ []) do
+  def get(resource, headers \\ default_headers, opt \\ []) do
     Logger.debug "Sending GET request to the Docker HTTP API: #{resource}"
     base_url <> resource
     |> HTTPoison.get!(headers, Keyword.merge(options, opt))
@@ -25,7 +28,7 @@ defmodule Dockerex.Client do
   @doc """
   Send a POST request to the Docker API, JSONifying the passed in data.
   """
-  def post(resource, data \\ "", headers \\ @default_headers, opt \\ []) do
+  def post(resource, data \\ "", headers \\ default_headers, opt \\ []) do
     Logger.debug "Sending POST request to the Docker HTTP API: #{resource}, #{inspect data}"
     data = Poison.encode! data
     base_url <> resource
@@ -36,7 +39,7 @@ defmodule Dockerex.Client do
   @doc """
   Send a DELETE request to the Docker API.
   """
-  def delete(resource, headers \\ @default_headers, opt \\ []) do
+  def delete(resource, headers \\ default_headers, opt \\ []) do
     Logger.debug "Sending DELETE request to the Docker HTTP API: #{resource}"
     base_url <> resource
     |> HTTPoison.delete!(headers, Keyword.merge(options, opt))

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule Dockerex.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:poison, "~> 2.2.0"},
       {:httpoison, "~> 0.11.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -30,8 +30,7 @@ defmodule Dockerex.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:poison, "~> 2.2.0"},
-      {:httpoison, "~> 0.9.0"},
+      {:httpoison, "~> 0.11.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
-%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+%{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
-  "httpoison": {:hex, :httpoison, "0.9.0", "68187a2daddfabbe7ca8f7d75ef227f89f0e1507f7eecb67e4536b3c516faddb", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
+  "httpoison": {:hex, :httpoison, "0.11.0", "b9240a9c44fc46fcd8618d17898859ba09a3c1b47210b74316c0ffef10735e76", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
I updated the HTTPoison dependency to a version which also supports unix sockets. This makes it possible to connect to docker over a local unix socket. I also added a default HTTP Host header which is required by Go 1.16 and would result in a "400 Bad Request: malformed Host header" error from the docker daemon when omitted.