### PR TITLE
Default options to empty array

### DIFF
--- a/lib/dockerex/client.ex
+++ b/lib/dockerex/client.ex
@@ -7,7 +7,7 @@ defmodule Dockerex.Client do
   end
 
   defp options do
-    Application.get_env(:dockerex, :options)
+    Application.get_env(:dockerex, :options, [])
   end
 
   defp default_headers do

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Dockerex.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:httpoison, :logger]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Hi,
thanks for the library, I am using it with unix socket so I don't need to specify any options, so I thought I would make the field optional and default to [], feel free to merge if any useful.
cheers
andrea